### PR TITLE
add CTestTestfile.cmake into CMake.gitignore

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -4,3 +4,4 @@ CMakeScripts
 Makefile
 cmake_install.cmake
 install_manifest.txt
+CTestTestfile.cmake


### PR DESCRIPTION
**Reasons for making this change:**

`CTestTestfile.cmake` is automatically generated by CMake when invoking `enable_testing()` command in CMakeLists.txt.

As the file itself says:

```
# CMake generated Testfile for
# Source directory: ...
# Build directory: ...
#
# This file includes the relevant testing commands required for
# testing this directory and lists subdirectories to be tested as well.
```
